### PR TITLE
fix: tooltip created after view destroyed

### DIFF
--- a/src/util/triggers.ts
+++ b/src/util/triggers.ts
@@ -96,5 +96,6 @@ export function listenToTriggers(
 		}
 	}
 
+	cleanupFns.push(() => clearTimeout(timeout));
 	return () => cleanupFns.forEach((cleanupFn) => cleanupFn());
 }


### PR DESCRIPTION
Error found clicking through column filters in BugSplat web app.